### PR TITLE
Default truthy value for this.compiled prevented compilation

### DIFF
--- a/dist/DeployEngine.js
+++ b/dist/DeployEngine.js
@@ -42,12 +42,12 @@ var DeployEngine = function (_StateEngine) {
   function DeployEngine(options) {
     _classCallCheck(this, DeployEngine);
 
-    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(DeployEngine).call(this, options));
+    var _this = _possibleConstructorReturn(this, (DeployEngine.__proto__ || Object.getPrototypeOf(DeployEngine)).call(this, options));
 
     _this.contractDir = options.contractDir || process.cwd() + '/contracts';
     _this.deployedDir = options.deployedDir || process.cwd() + '/deployed';
     _this.compiledDir = options.compiledDir || process.cwd() + '/compiled';
-    _this.compiled = options.compiled || {};
+    _this.compiled = options.compiled || null;
     _this.fileName = options.fileName || options.contractName;
     _this.deployed = {};
     _this.params = options.params;
@@ -113,8 +113,10 @@ var DeployEngine = function (_StateEngine) {
       return new _bluebird2.default(function (resolve, reject) {
         _bluebird2.default.resolve(fs.existsSync(_this4.compiledDir + '/compiled.json')).then(function (exists) {
           if (!exists) {
+            console.log('compiled.json does not exists');
             _this4.compiled ? resolve(_this4.compiled) : resolve(null);
           } else {
+            console.log('compiled.json exists');
             return jsonfile.readFileAsync(_this4.compiledDir + '/compiled.json');
           }
         }).then(function (compiled) {
@@ -136,11 +138,15 @@ var DeployEngine = function (_StateEngine) {
         _this5.deployed = new Object();
         _this5.getCompiled().then(function (compiled) {
           if (!compiled) {
+            console.log('Compiling');
             return _this5.compile();
           } else {
+            console.log('Found compiled');
             return compiled;
           }
         }).then(function (compiled) {
+          console.log("FINNA DIE");
+          console.log(compiled);
           _this5.deployed = compiled['contracts'][_this5.contractName];
           _this5.abi = JSON.parse(compiled['contracts'][_this5.contractName]['interface']);
           return _this5.linkBytecode(compiled['contracts'][_this5.contractName]['bytecode']);
@@ -153,10 +159,10 @@ var DeployEngine = function (_StateEngine) {
             if (!_this5.privateKey) {
               return contract.new(_this5.sendObject);
             } else {
-              var _sendObject = _this5.sendObject;
-              var from = _sendObject.from;
-              var value = _sendObject.value;
-              var gas = _sendObject.gas;
+              var _sendObject = _this5.sendObject,
+                  from = _sendObject.from,
+                  value = _sendObject.value,
+                  gas = _sendObject.gas;
 
               var data = contract.new.getData({ data: '0x' + _this5.bytecode });
               var to = null;
@@ -168,10 +174,10 @@ var DeployEngine = function (_StateEngine) {
             } else {
               var _contract$new;
 
-              var _sendObject2 = _this5.sendObject;
-              var _from = _sendObject2.from;
-              var _value = _sendObject2.value;
-              var _gas = _sendObject2.gas;
+              var _sendObject2 = _this5.sendObject,
+                  _from = _sendObject2.from,
+                  _value = _sendObject2.value,
+                  _gas = _sendObject2.gas;
 
               var _data = (_contract$new = contract.new).getData.apply(_contract$new, _toConsumableArray(_this5.params).concat([{ data: '0x' + _this5.bytecode }]));
               var _to = null;

--- a/dist/StateEngine.js
+++ b/dist/StateEngine.js
@@ -388,7 +388,7 @@ var StateEngine = function () {
   }, {
     key: 'reducer',
     value: function reducer() {
-      var state = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+      var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
       var action = arguments[1];
 
       switch (action.type) {

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "babel-preset-stage-0": "^6.5.0",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0"
+  },
+  "babel": {
+    "presets": ["es2015"]
   }
 }

--- a/src/contractDeployEngine.js
+++ b/src/contractDeployEngine.js
@@ -13,7 +13,7 @@ export default class DeployEngine extends StateEngine {
     this.contractDir = options.contractDir || `${process.cwd()}/contracts`;
     this.deployedDir = options.deployedDir || `${process.cwd()}/deployed`;
     this.compiledDir = options.compiledDir || `${process.cwd()}/compiled`;
-    this.compiled = options.compiled || {};
+    this.compiled = options.compiled || null;
     this.fileName = options.fileName || options.contractName;
     this.deployed = {};
     this.params = options.params;


### PR DESCRIPTION
When a `compiled.json` file did not already exist, the truthy default value of `this.compiled` (an empty object) prevented compilation from ever taking place.

[This line](https://github.com/Ryanmtate/redux-solidity/blob/master/src/contractDeployEngine.js#L71) resolved to a truthy value (an empty object), so [this line](https://github.com/Ryanmtate/redux-solidity/blob/master/src/contractDeployEngine.js#L90) which should evaluate as true when `compiled.json` doesn't exist would evaluate as false.