### PR TITLE
Adds option to set a default delay to submitting signed transactions.

### DIFF
--- a/dist/StateEngine.js
+++ b/dist/StateEngine.js
@@ -47,7 +47,7 @@ var StateEngine = function () {
     this.logs = undefined;
     this.abi && this.address ? this.contract = this.eth.contract(this.abi).at(this.address) : this.contract = null;
     this.contract ? this.events = this.contract.allEvents({ fromBlock: this.deployedBlockNumber, toBlock: 'latest' }) : null;
-    this.timeout = 0 || options.timeout;
+    this.txnTimeout = 0 || options.txnTimeout; // Default timeout for sending a signed txn
   }
 
   _createClass(StateEngine, [{
@@ -262,14 +262,17 @@ var StateEngine = function () {
     }
   }, {
     key: 'sendSigned',
-    value: function sendSigned(_from, _to, _value, _gasLimit, _data, _privateKey, _nonce) {
+    value: function sendSigned(_from, _to, _value, _gasLimit, _data, _privateKey, _nonce, _delay) {
       var _this9 = this;
 
       return new _bluebird2.default(function (resolve, reject) {
         if (!_from || !_data) {
           reject(new Error('Invalid _from or _data field'));
         };
-        _bluebird2.default.delay(_this9.timeout).then(function () {
+        // Option to override default delay if one is specified
+        var delay = _delay || _this9.txnTimeout;
+
+        _bluebird2.default.delay(_this9.txnTimeout).then(function () {
           return _bluebird2.default.resolve([_this9.eth.getGasPriceAsync(), _this9.eth.getTransactionCountAsync(_from)]);
         }).spread(function (gasPrice, n) {
           var nonce = _nonce || Number(n.toString());

--- a/dist/StateEngine.js
+++ b/dist/StateEngine.js
@@ -47,6 +47,7 @@ var StateEngine = function () {
     this.logs = undefined;
     this.abi && this.address ? this.contract = this.eth.contract(this.abi).at(this.address) : this.contract = null;
     this.contract ? this.events = this.contract.allEvents({ fromBlock: this.deployedBlockNumber, toBlock: 'latest' }) : null;
+    this.timeout = 0 || options.timeout;
   }
 
   _createClass(StateEngine, [{
@@ -268,7 +269,9 @@ var StateEngine = function () {
         if (!_from || !_data) {
           reject(new Error('Invalid _from or _data field'));
         };
-        _bluebird2.default.resolve([_this9.eth.getGasPriceAsync(), _this9.eth.getTransactionCountAsync(_from)]).spread(function (gasPrice, n) {
+        _bluebird2.default.delay(_this9.timeout).then(function () {
+          return _bluebird2.default.resolve([_this9.eth.getGasPriceAsync(), _this9.eth.getTransactionCountAsync(_from)]);
+        }).spread(function (gasPrice, n) {
           var nonce = _nonce || Number(n.toString());
           var rawTx = {
             from: _from,
@@ -389,7 +392,7 @@ var StateEngine = function () {
   }, {
     key: 'reducer',
     value: function reducer() {
-      var state = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+      var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
       var action = arguments[1];
 
       switch (action.type) {

--- a/src/contractStateEngine.js
+++ b/src/contractStateEngine.js
@@ -22,7 +22,7 @@ export default class StateEngine {
     this.contract ?
       this.events = this.contract.allEvents({fromBlock : this.deployedBlockNumber, toBlock : 'latest'}) :
       null;
-    this.timeout = 0 || options.timeout;
+    this.txnTimeout = 0 || options.txnTimeout;  // Default timeout for sending a signed txn
   }
 
 
@@ -201,12 +201,15 @@ export default class StateEngine {
     });
   }
 
-  sendSigned(_from, _to, _value, _gasLimit, _data, _privateKey, _nonce) {
+  sendSigned(_from, _to, _value, _gasLimit, _data, _privateKey, _nonce, _delay) {
     return new Promise((resolve, reject) => {
       if (!_from || !_data) {
         reject(new Error('Invalid _from or _data field'));
       };
-      Promise.delay(this.timeout)
+      // Option to override default delay if one is specified
+      let delay = _delay || this.txnTimeout;
+
+      Promise.delay(this.txnTimeout)
       .then(() => {
         return Promise.resolve([
           this.eth.getGasPriceAsync(),

--- a/src/contractStateEngine.js
+++ b/src/contractStateEngine.js
@@ -22,6 +22,7 @@ export default class StateEngine {
     this.contract ?
       this.events = this.contract.allEvents({fromBlock : this.deployedBlockNumber, toBlock : 'latest'}) :
       null;
+    this.timeout = 0 || options.timeout;
   }
 
 
@@ -205,10 +206,14 @@ export default class StateEngine {
       if (!_from || !_data) {
         reject(new Error('Invalid _from or _data field'));
       };
-      Promise.resolve([
-        this.eth.getGasPriceAsync(),
-        this.eth.getTransactionCountAsync(_from)
-      ]).spread((gasPrice, n) => {
+      Promise.delay(this.timeout)
+      .then(() => {
+        return Promise.resolve([
+          this.eth.getGasPriceAsync(),
+          this.eth.getTransactionCountAsync(_from)
+        ])
+      })
+      .spread((gasPrice, n) => {
         let nonce = _nonce || Number(n.toString());
         let rawTx = {
           from: _from,


### PR DESCRIPTION
If the Ethereum client has a rate limit to the number of transactions it can receive, an application that submits signed transactions with a high frequency may see some of those transactions bounced or held indefinitely in the txn pool.

This PR adds an option to the `StateEngine` object to allow a default `txnTimeout` that will add a delay (in ms) before sending a signed transaction via the `sendSigned` function. The default is 0 ms.

The timeout may be specified for any individual sendSigned call by including an optional `_default` param in the function call.